### PR TITLE
Remove explicit Java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,10 +33,6 @@
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
-  <properties>
-    <java.version>1.8</java.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Spring Boot 2 requires Java 8 and sets this property by default.