### PR TITLE
Remove explicit dependency on assertj-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.6</version>


### PR DESCRIPTION
It's part of the starter-test.